### PR TITLE
1.10

### DIFF
--- a/custom_components/tdarr/sensor.py
+++ b/custom_components/tdarr/sensor.py
@@ -46,9 +46,15 @@ class TdarrSensor(
         if self.type == "server":
             self._device_id = "tdarr_server"
         elif self.type == "node":
-            self._device_id = "tdarr_node_" + self.sensor["_id"]
+            if "nodeName" in self.sensor:
+                self._device_id = "tdarr_node_" + self.sensor["nodeName"]
+            else:
+                self._device_id = "tdarr_node_" + self.sensor["_id"]
         elif self.type == "nodefps":
-            self._device_id = "tdarr_node_" + self.sensor["_id"] + "_fps"
+            if "nodeName" in self.sensor:
+                self._device_id = "tdarr_node_" + self.sensor["nodeName"] + "_fps"
+            else:
+                self._device_id = "tdarr_node_" + self.sensor["_id"] + "_fps"
         elif self.type == "library":
             self._device_id = "tdarr_library_" + self.sensor[1]
         else:

--- a/custom_components/tdarr/switch.py
+++ b/custom_components/tdarr/switch.py
@@ -20,7 +20,7 @@ class Switch(TdarrEntity, SwitchEntity):
     """Define the Switch for turning ignition off/on"""
 
     def __init__(self, coordinator, switch, options):
-        if "nodeName" in self.switch:
+        if "nodeName" in switch:
             self._device_id = "tdarr_node_" + switch["nodeName"] + "_paused"
         else:
             self._device_id = "tdarr_node_" + switch["_id"] + "_paused"

--- a/custom_components/tdarr/switch.py
+++ b/custom_components/tdarr/switch.py
@@ -20,8 +20,10 @@ class Switch(TdarrEntity, SwitchEntity):
     """Define the Switch for turning ignition off/on"""
 
     def __init__(self, coordinator, switch, options):
-
-        self._device_id = "tdarr_node_" + switch["_id"] + "_paused"
+        if "nodeName" in self.switch:
+            self._device_id = "tdarr_node_" + switch["nodeName"] + "_paused"
+        else:
+            self._device_id = "tdarr_node_" + switch["_id"] + "_paused"
         self.switch = switch
         self.coordinator = coordinator
         self._state = None


### PR DESCRIPTION
Disable using NodeID for now as it changes everytime a node is restarted or reloaded and can't be set by the user. Now just uses Node Name.