### PR TITLE
Setting self.config_entry will become deprecated in 2025.12

### DIFF
--- a/custom_components/tdarr/config_flow.py
+++ b/custom_components/tdarr/config_flow.py
@@ -31,7 +31,7 @@ async def validate_input(hass: core.HomeAssistant, data):
 
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
-    
+
     tdarr = Server(data[SERVERIP], data[SERVERPORT], data[APIKEY])
 
     result = await hass.async_add_executor_job(tdarr.getSettings)
@@ -79,13 +79,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return OptionsFlow(config_entry)
+        return OptionsFlowHandler()
 
-class OptionsFlow(config_entries.OptionsFlow):
-    def __init__(self, config_entry: config_entries.ConfigEntry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
+class OptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         if user_input is not None:
             if SERVERIP in self.config_entry.data:
@@ -119,6 +115,3 @@ class InvalidAPIKEY(exceptions.HomeAssistantError):
 
 class AuthRequired(exceptions.HomeAssistantError):
     """Error to indicate Auth is required"""
-
-
-


### PR DESCRIPTION
Fixes the following upcoming deprecation
```
2025-01-18 14:57:43.878 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'tdarr' sets option flow config_entry explicitly, which is deprecated at custom_components/tdarr/config_flow.py, line 87: self.config_entry = config_entry. This will stop working in Home Assistant 2025.12, please create a bug report at https://github.com/itchannel/tdarr_ha/issues
```

Not entirely sure if this is the best way to fix it, I just looked at other components to see what's changed.