### PR TITLE
Migrate to using EntityDescription classes

### DIFF
--- a/custom_components/tdarr/const.py
+++ b/custom_components/tdarr/const.py
@@ -8,15 +8,15 @@ COORDINATOR = "coordinator"
 APIKEY = "apikey"
 
 SENSORS = {
-    "server": {"type": "single", "entry": "server"},
-    "stats_spacesaved": {"type": "single", "entry": "stats"},
-    "stats_transcodefilesremaining": {"type": "single", "entry": "stats"},
-    "stats_transcodedcount": {"type": "single", "entry": "stats"},
-    "stats_stagedcount": {"type": "single", "entry": "staged"},
-    "stats_healthcount": {"type": "single", "entry": "stats"},
-    "stats_transcodeerrorcount": {"type": "single", "entry": "stats"},
-    "stats_healtherrorcount": {"type": "single", "entry": "stats"},
-    "stats_totalfps": {"type": "single", "entry": "nodes"},
+    "server": {"entry": "server"},
+    "stats_spacesaved": {"entry": "stats"},
+    "stats_transcodefilesremaining": {"entry": "stats"},
+    "stats_transcodedcount": {"entry": "stats"},
+    "stats_stagedcount": {"entry": "staged"},
+    "stats_healthcount": {"entry": "stats"},
+    "stats_transcodeerrorcount": {"entry": "stats"},
+    "stats_healtherrorcount": {"entry": "stats"},
+    "stats_totalfps": {"entry": "nodes"},
 }
 
 SWITCHES = {

--- a/custom_components/tdarr/const.py
+++ b/custom_components/tdarr/const.py
@@ -8,18 +8,18 @@ COORDINATOR = "coordinator"
 APIKEY = "apikey"
 
 SENSORS = {
-    "server": {"icon": "mdi:server", "type": "single", "entry": "server"},
-    "stats_spacesaved": {"icon": "mdi:harddisk","type": "single", "entry": "stats", "unit_of_measurement": "GB", "device_class": "data_size"},
-    "stats_transcodefilesremaining": {"icon": "mdi:file-multiple", "unit_of_measurement": "Files", "type": "single", "entry": "stats"},
-    "stats_transcodedcount": {"icon": "mdi:file-multiple", "unit_of_measurement": "Files", "type": "single", "entry": "stats"},
-    "stats_stagedcount": {"icon": "mdi:file-multiple", "unit_of_measurement": "Files", "type": "single", "entry": "staged"},
-    "stats_healthcount": {"icon": "mdi:file-multiple", "unit_of_measurement": "Files", "type": "single", "entry": "stats"},
-    "stats_transcodeerrorcount": {"icon": "mdi:file-multiple", "unit_of_measurement": "Files", "type": "single", "entry": "stats"},
-    "stats_healtherrorcount": {"icon": "mdi:medication-outline", "unit_of_measurement": "Files", "type": "single", "entry": "stats"},
-    "node": {"icon": "mdi:server-network-outline"},
-    "nodefps": {"icon": "mdi:video", "unit_of_measurement": "FPS"},
-    "stats_totalfps": {"icon": "mdi:video", "unit_of_measurement": "FPS", "type": "single", "entry": "nodes"},
-    "library": {"icon": "mdi:folder-multiple", "unit_of_measurement": "Files"},
+    "server": {"type": "single", "entry": "server"},
+    "stats_spacesaved": {"entry": "stats", "device_class": "data_size"},
+    "stats_transcodefilesremaining": {"type": "single", "entry": "stats"},
+    "stats_transcodedcount": {"type": "single", "entry": "stats"},
+    "stats_stagedcount": {"type": "single", "entry": "staged"},
+    "stats_healthcount": {"type": "single", "entry": "stats"},
+    "stats_transcodeerrorcount": {"type": "single", "entry": "stats"},
+    "stats_healtherrorcount": {"type": "single", "entry": "stats"},
+    "node": {},
+    "nodefps": {},
+    "stats_totalfps": {"type": "single", "entry": "nodes"},
+    "library": {},
 }
 
 SWITCHES = {

--- a/custom_components/tdarr/const.py
+++ b/custom_components/tdarr/const.py
@@ -16,10 +16,7 @@ SENSORS = {
     "stats_healthcount": {"type": "single", "entry": "stats"},
     "stats_transcodeerrorcount": {"type": "single", "entry": "stats"},
     "stats_healtherrorcount": {"type": "single", "entry": "stats"},
-    "node": {},
-    "nodefps": {},
     "stats_totalfps": {"type": "single", "entry": "nodes"},
-    "library": {},
 }
 
 SWITCHES = {

--- a/custom_components/tdarr/const.py
+++ b/custom_components/tdarr/const.py
@@ -18,8 +18,3 @@ SENSORS = {
     "stats_healtherrorcount": {"entry": "stats"},
     "stats_totalfps": {"entry": "nodes"},
 }
-
-SWITCHES = {
-    "pauseAll": {"icon": "mdi:pause-circle", "name": "pauseAll", "data": "globalsettings"},
-    "ignoreSchedules": {"icon": "mdi:calendar-remove", "name": "ignoreSchedules", "data": "globalsettings"},
-}

--- a/custom_components/tdarr/const.py
+++ b/custom_components/tdarr/const.py
@@ -9,7 +9,7 @@ APIKEY = "apikey"
 
 SENSORS = {
     "server": {"type": "single", "entry": "server"},
-    "stats_spacesaved": {"entry": "stats"},
+    "stats_spacesaved": {"type": "single", "entry": "stats"},
     "stats_transcodefilesremaining": {"type": "single", "entry": "stats"},
     "stats_transcodedcount": {"type": "single", "entry": "stats"},
     "stats_stagedcount": {"type": "single", "entry": "staged"},

--- a/custom_components/tdarr/const.py
+++ b/custom_components/tdarr/const.py
@@ -9,7 +9,7 @@ APIKEY = "apikey"
 
 SENSORS = {
     "server": {"type": "single", "entry": "server"},
-    "stats_spacesaved": {"entry": "stats", "device_class": "data_size"},
+    "stats_spacesaved": {"entry": "stats"},
     "stats_transcodefilesremaining": {"type": "single", "entry": "stats"},
     "stats_transcodedcount": {"type": "single", "entry": "stats"},
     "stats_stagedcount": {"type": "single", "entry": "staged"},

--- a/custom_components/tdarr/sensor.py
+++ b/custom_components/tdarr/sensor.py
@@ -3,6 +3,7 @@ import re
 
 from homeassistant.components.sensor import (
     SensorEntity,
+    SensorEntityDescription,
     SensorDeviceClass,
     SensorStateClass
 )
@@ -12,6 +13,71 @@ from .const import DOMAIN, COORDINATOR, SENSORS
 
 _LOGGER = logging.getLogger(__name__)
 
+SERVER_ENTITY_DESCRIPTIONS = {
+    "server": SensorEntityDescription(
+        key="server",
+        icon="mdi:server"
+    ),
+    "stats_spacesaved": SensorEntityDescription(
+        key="stats_spacesaved",
+        icon="mdi:harddisk",
+        unit_of_measurement="GB"
+    ),
+    "stats_transcodefilesremaining": SensorEntityDescription(
+        key="stats_transcodefilesremaining",
+        icon="mdi:file-multiple",
+        unit_of_measurement="Files"
+    ),
+    "stats_transcodedcount": SensorEntityDescription(
+        key="stats_transcodedcount",
+        icon="mdi:file-multiple",
+        unit_of_measurement="Files"
+    ),
+    "stats_stagedcount": SensorEntityDescription(
+        key="stats_stagedcount",
+        icon="mdi:file-multiple",
+        unit_of_measurement="Files"
+    ),
+    "stats_healthcount": SensorEntityDescription(
+        key="stats_healthcount",
+        icon="mdi:file-multiple",
+        unit_of_measurement="Files"
+    ),
+    "stats_transcodeerrorcount": SensorEntityDescription(
+        key="stats_transcodeerrorcount",
+        icon="mdi:file-multiple",
+        unit_of_measurement="Files"
+    ),
+    "stats_healtherrorcount": SensorEntityDescription(
+        key="stats_healtherrorcount",
+        icon="mdi:medication-outline",
+        unit_of_measurement="Files"
+    ),
+    "stats_totalfps": SensorEntityDescription(
+        key="stats_totalfps",
+        icon="mdi:video",
+        unit_of_measurement="FPS"
+    ),
+}
+
+LIBRARY_ENTITY_DESCRIPTION=SensorEntityDescription(
+    key="library",
+    icon="mdi:folder-multiple",
+    unit_of_measurement="Files"
+)
+
+NODE_ENTITY_DESCRIPTIONS={
+    "node": SensorEntityDescription(
+        key="node",
+        icon="mdi:server-network-outline",
+    ),
+    "nodefps": SensorEntityDescription(
+        key="node",
+        icon="mdi:video",
+        unit_of_measurement="FPS"
+    )
+}
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Add the Entities from the config."""
     entry = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
@@ -20,18 +86,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     #_LOGGER.debug(entry.data)
     for key, value in SENSORS.items():
         if value.get("type", "") == "single":
-            sensors.append(TdarrSensor(entry, entry.data[value["entry"]], config_entry.options, key))
+            sensors.append(TdarrSensor(entry, entry.data[value["entry"]], config_entry.options, key, SERVER_ENTITY_DESCRIPTIONS[key]))
     # Server Library Sensors
     id = 0
     for value in entry.data["libraries"]:
         #value.insert(0, id)
-        sensors.append(TdarrSensor(entry, value, config_entry.options, "library"))
+        sensors.append(TdarrSensor(entry, value, config_entry.options, "library", LIBRARY_ENTITY_DESCRIPTION))
         id += 1
     # Server Node Sensors
     fps_count = 0
     for key, value in entry.data["nodes"].items():
-        sensors.append(TdarrSensor(entry, value, config_entry.options, "node"))
-        sensors.append(TdarrSensor(entry, value, config_entry.options, "nodefps"))
+        sensors.append(TdarrSensor(entry, value, config_entry.options, "node", NODE_ENTITY_DESCRIPTIONS["node"]))
+        sensors.append(TdarrSensor(entry, value, config_entry.options, "nodefps", NODE_ENTITY_DESCRIPTIONS["nodefps"]))
     
 
     async_add_entities(sensors, True)
@@ -41,11 +107,12 @@ class TdarrSensor(
     TdarrEntity,
     SensorEntity,
 ):
-    def __init__(self, coordinator, sensor, options, type):
+    def __init__(self, coordinator, sensor, options, type, entity_description: SensorEntityDescription):
 
         self.sensor = sensor
         self.tdarroptions = options
         self.type = type
+        self.entity_description = entity_description
         self._attr = {}
         self.coordinator = coordinator
         if self.type == "server":
@@ -171,18 +238,10 @@ class TdarrSensor(
     @property
     def extra_state_attributes(self):
         return self.get_value("attributes")
-
-    @property
-    def native_unit_of_measurement(self):
-        return SENSORS.get(self.type, {}).get("unit_of_measurement", None)
-
+    
     @property
     def device_class(self):
         return SENSORS.get(self.type, {}).get("device_class", None)
-
-    @property
-    def icon(self):
-        return SENSORS.get(self.type, {}).get("icon", None)
     
     @property
     def state_class(self):

--- a/custom_components/tdarr/sensor.py
+++ b/custom_components/tdarr/sensor.py
@@ -14,47 +14,47 @@ from .const import DOMAIN, COORDINATOR, SENSORS
 _LOGGER = logging.getLogger(__name__)
 
 SERVER_ENTITY_DESCRIPTIONS = {
-    "server": SensorEntityDescription(
+    SensorEntityDescription(
         key="server",
         icon="mdi:server"
     ),
-    "stats_spacesaved": SensorEntityDescription(
+    SensorEntityDescription(
         key="stats_spacesaved",
         icon="mdi:harddisk",
         native_unit_of_measurement="GB",
         device_class=SensorDeviceClass.DATA_SIZE
     ),
-    "stats_transcodefilesremaining": SensorEntityDescription(
+    SensorEntityDescription(
         key="stats_transcodefilesremaining",
         icon="mdi:file-multiple",
         native_unit_of_measurement="files"
     ),
-    "stats_transcodedcount": SensorEntityDescription(
+    SensorEntityDescription(
         key="stats_transcodedcount",
         icon="mdi:file-multiple",
         native_unit_of_measurement="files"
     ),
-    "stats_stagedcount": SensorEntityDescription(
+    SensorEntityDescription(
         key="stats_stagedcount",
         icon="mdi:file-multiple",
         native_unit_of_measurement="files"
     ),
-    "stats_healthcount": SensorEntityDescription(
+    SensorEntityDescription(
         key="stats_healthcount",
         icon="mdi:file-multiple",
         native_unit_of_measurement="files"
     ),
-    "stats_transcodeerrorcount": SensorEntityDescription(
+    SensorEntityDescription(
         key="stats_transcodeerrorcount",
         icon="mdi:file-multiple",
         native_unit_of_measurement="files"
     ),
-    "stats_healtherrorcount": SensorEntityDescription(
+    SensorEntityDescription(
         key="stats_healtherrorcount",
         icon="mdi:medication-outline",
         native_unit_of_measurement="files"
     ),
-    "stats_totalfps": SensorEntityDescription(
+    SensorEntityDescription(
         key="stats_totalfps",
         icon="mdi:video",
         native_unit_of_measurement="fps"
@@ -68,11 +68,11 @@ LIBRARY_ENTITY_DESCRIPTION = SensorEntityDescription(
 )
 
 NODE_ENTITY_DESCRIPTIONS = {
-    "node": SensorEntityDescription(
+    SensorEntityDescription(
         key="node",
         icon="mdi:server-network-outline",
     ),
-    "nodefps": SensorEntityDescription(
+    SensorEntityDescription(
         key="nodefps",
         icon="mdi:video",
         native_unit_of_measurement="fps"
@@ -85,8 +85,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     sensors = []
     # Server Status Sensor
     #_LOGGER.debug(entry.data)
-    for key, value in SENSORS.items():
-        sensors.append(TdarrSensor(entry, entry.data[value["entry"]], config_entry.options, SERVER_ENTITY_DESCRIPTIONS[key]))
+    for description in SERVER_ENTITY_DESCRIPTIONS:
+        legacy_sensor_dict_value = SENSORS[description.key]
+        sensors.append(TdarrSensor(entry, entry.data[legacy_sensor_dict_value["entry"]], config_entry.options, description))
     # Server Library Sensors
     id = 0
     for value in entry.data["libraries"]:
@@ -96,8 +97,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     # Server Node Sensors
     fps_count = 0
     for key, value in entry.data["nodes"].items():
-        sensors.append(TdarrSensor(entry, value, config_entry.options, NODE_ENTITY_DESCRIPTIONS["node"]))
-        sensors.append(TdarrSensor(entry, value, config_entry.options, NODE_ENTITY_DESCRIPTIONS["nodefps"]))
+        for description in NODE_ENTITY_DESCRIPTIONS:
+            sensors.append(TdarrSensor(entry, value, config_entry.options, description))
     
 
     async_add_entities(sensors, True)

--- a/custom_components/tdarr/sensor.py
+++ b/custom_components/tdarr/sensor.py
@@ -61,19 +61,19 @@ SERVER_ENTITY_DESCRIPTIONS = {
     ),
 }
 
-LIBRARY_ENTITY_DESCRIPTION=SensorEntityDescription(
+LIBRARY_ENTITY_DESCRIPTION = SensorEntityDescription(
     key="library",
     icon="mdi:folder-multiple",
     unit_of_measurement="Files"
 )
 
-NODE_ENTITY_DESCRIPTIONS={
+NODE_ENTITY_DESCRIPTIONS = {
     "node": SensorEntityDescription(
         key="node",
         icon="mdi:server-network-outline",
     ),
     "nodefps": SensorEntityDescription(
-        key="node",
+        key="nodefps",
         icon="mdi:video",
         unit_of_measurement="FPS"
     )

--- a/custom_components/tdarr/sensor.py
+++ b/custom_components/tdarr/sensor.py
@@ -21,7 +21,8 @@ SERVER_ENTITY_DESCRIPTIONS = {
     "stats_spacesaved": SensorEntityDescription(
         key="stats_spacesaved",
         icon="mdi:harddisk",
-        unit_of_measurement="GB"
+        unit_of_measurement="GB",
+        device_class=SensorDeviceClass.DATA_SIZE
     ),
     "stats_transcodefilesremaining": SensorEntityDescription(
         key="stats_transcodefilesremaining",
@@ -238,10 +239,6 @@ class TdarrSensor(
     @property
     def extra_state_attributes(self):
         return self.get_value("attributes")
-    
-    @property
-    def device_class(self):
-        return SENSORS.get(self.type, {}).get("device_class", None)
     
     @property
     def state_class(self):

--- a/custom_components/tdarr/sensor.py
+++ b/custom_components/tdarr/sensor.py
@@ -86,8 +86,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     # Server Status Sensor
     #_LOGGER.debug(entry.data)
     for key, value in SENSORS.items():
-        if value.get("type", "") == "single":
-            sensors.append(TdarrSensor(entry, entry.data[value["entry"]], config_entry.options, key, SERVER_ENTITY_DESCRIPTIONS[key]))
+        sensors.append(TdarrSensor(entry, entry.data[value["entry"]], config_entry.options, key, SERVER_ENTITY_DESCRIPTIONS[key]))
     # Server Library Sensors
     id = 0
     for value in entry.data["libraries"]:

--- a/custom_components/tdarr/sensor.py
+++ b/custom_components/tdarr/sensor.py
@@ -21,50 +21,50 @@ SERVER_ENTITY_DESCRIPTIONS = {
     "stats_spacesaved": SensorEntityDescription(
         key="stats_spacesaved",
         icon="mdi:harddisk",
-        unit_of_measurement="GB",
+        native_unit_of_measurement="GB",
         device_class=SensorDeviceClass.DATA_SIZE
     ),
     "stats_transcodefilesremaining": SensorEntityDescription(
         key="stats_transcodefilesremaining",
         icon="mdi:file-multiple",
-        unit_of_measurement="Files"
+        native_unit_of_measurement="files"
     ),
     "stats_transcodedcount": SensorEntityDescription(
         key="stats_transcodedcount",
         icon="mdi:file-multiple",
-        unit_of_measurement="Files"
+        native_unit_of_measurement="files"
     ),
     "stats_stagedcount": SensorEntityDescription(
         key="stats_stagedcount",
         icon="mdi:file-multiple",
-        unit_of_measurement="Files"
+        native_unit_of_measurement="files"
     ),
     "stats_healthcount": SensorEntityDescription(
         key="stats_healthcount",
         icon="mdi:file-multiple",
-        unit_of_measurement="Files"
+        native_unit_of_measurement="files"
     ),
     "stats_transcodeerrorcount": SensorEntityDescription(
         key="stats_transcodeerrorcount",
         icon="mdi:file-multiple",
-        unit_of_measurement="Files"
+        native_unit_of_measurement="files"
     ),
     "stats_healtherrorcount": SensorEntityDescription(
         key="stats_healtherrorcount",
         icon="mdi:medication-outline",
-        unit_of_measurement="Files"
+        native_unit_of_measurement="files"
     ),
     "stats_totalfps": SensorEntityDescription(
         key="stats_totalfps",
         icon="mdi:video",
-        unit_of_measurement="FPS"
+        native_unit_of_measurement="fps"
     ),
 }
 
 LIBRARY_ENTITY_DESCRIPTION = SensorEntityDescription(
     key="library",
     icon="mdi:folder-multiple",
-    unit_of_measurement="Files"
+    native_unit_of_measurement="files"
 )
 
 NODE_ENTITY_DESCRIPTIONS = {
@@ -75,7 +75,7 @@ NODE_ENTITY_DESCRIPTIONS = {
     "nodefps": SensorEntityDescription(
         key="nodefps",
         icon="mdi:video",
-        unit_of_measurement="FPS"
+        native_unit_of_measurement="fps"
     )
 }
 
@@ -234,7 +234,6 @@ class TdarrSensor(
     @property 
     def native_value(self):
         return self.get_value("state")
-
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/tdarr/switch.py
+++ b/custom_components/tdarr/switch.py
@@ -1,31 +1,48 @@
 import logging
 import time
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import (
+    SwitchEntity,
+    SwitchEntityDescription
+)
 
 from . import TdarrEntity
-from .const import DOMAIN, COORDINATOR, SWITCHES
+from .const import DOMAIN, COORDINATOR
 
 _LOGGER = logging.getLogger(__name__)
+
+SERVER_ENTITY_DESCRIPTIONS = {
+    SwitchEntityDescription(
+        key="pauseAll",
+        icon="mdi:pause-circle"
+    ),
+    SwitchEntityDescription(
+        key="ignoreSchedules",
+        icon="mdi:calendar-remove"
+    ),
+}
+
+NODE_PAUSE_ENTITY_DESCRIPTION = SwitchEntityDescription(
+    key="node_pause",
+)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Add the Switch from the config."""
     entry = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
     switches = []
     for key, value in entry.data["nodes"].items():
-        sw = Switch(entry, value, value["_id"], config_entry.options)
+        sw = Switch(entry, value, value["_id"], config_entry.options, NODE_PAUSE_ENTITY_DESCRIPTION)
         switches.append(sw)
 
-    for key, value in SWITCHES.items():
-        _LOGGER.debug(value)
-        switches.append(Switch(entry, entry.data["globalsettings"], value["name"], config_entry.options))
+    for description in SERVER_ENTITY_DESCRIPTIONS:
+        switches.append(Switch(entry, entry.data["globalsettings"], description.key, config_entry.options, description))
 
     async_add_entities(switches, False)
 
 class Switch(TdarrEntity, SwitchEntity):
     """Define the Switch for turning ignition off/on"""
 
-    def __init__(self, coordinator, switch, name, options):
+    def __init__(self, coordinator, switch, name, options, entity_description: SwitchEntityDescription):
         _LOGGER.debug(name)
         if "nodeName" in switch:
             self._device_id = "tdarr_node_" + switch["nodeName"] + "_paused"
@@ -37,6 +54,7 @@ class Switch(TdarrEntity, SwitchEntity):
             self._device_id = "tdarr_node_" + switch["_id"] + "_paused"
         self.switch = switch
         self.coordinator = coordinator
+        self.entity_description = entity_description
         self._state = None
         self.object_name = name
         # Required for HA 2022.7
@@ -54,9 +72,6 @@ class Switch(TdarrEntity, SwitchEntity):
             self.switch["nodePaused"] = True
             self.async_write_ha_state()
 
-
-
-           
     async def async_turn_off(self, **kwargs):
         update = await self.coordinator.hass.async_add_executor_job(
             self.coordinator.tdarr.pauseNode,
@@ -69,7 +84,6 @@ class Switch(TdarrEntity, SwitchEntity):
             self.switch["nodePaused"] = False
             self.async_write_ha_state()
 
-
     @property
     def name(self):
         #_LOGGER.debug(self.switch)
@@ -81,7 +95,6 @@ class Switch(TdarrEntity, SwitchEntity):
             return "tdarr_ignore_schedules"
         else:
             return "tdarr_node_" + self.switch["_id"] + "_paused"
-
 
     @property
     def device_id(self):
@@ -102,12 +115,6 @@ class Switch(TdarrEntity, SwitchEntity):
         for key, value in self.coordinator.data["nodes"].items():
             if value["_id"] == self.switch["_id"]:
                 return value["nodePaused"]
-
-
-
-    @property
-    def icon(self):
-        return SWITCHES.get(self.object_name, {}).get("icon", None)
 
     @property
     def extra_state_attributes(self):


### PR DESCRIPTION
As with PR #40 , I'm looking to make some improvements but am breaking things down into smaller chunks.

This PR migrates to using the `EntityDescription` classes in Home Assistant. The idea is to take advantage of native HA code, and have fewer overrides with custom implementations.

This is getting ready for the next pieces I hope to implement:

- Adding friendly sensor names (with i18n support if I can work it out)
- Moving data extraction from the if statements into the entity descriptions (similar to the `value_fn` here: https://github.com/home-assistant/core/blob/036eef2b6bc3941d05a53a050089f2e558df9e51/homeassistant/components/baf/sensor.py#L66)

This should drastically reduce the amount of entity code, and adding new sensors should then just be a case of adding a new entity description.

This is quite a big change, so it's worth noting that having a good functional basis to work from is very much appreciated. Thanks for all your work!