### PR TITLE
Add HTTPS/reverse proxy support with SSL options

### DIFF
--- a/custom_components/tdarr/__init__.py
+++ b/custom_components/tdarr/__init__.py
@@ -22,7 +22,9 @@ from .const import (
     UPDATE_INTERVAL,
     UPDATE_INTERVAL_DEFAULT,
     COORDINATOR,
-    APIKEY
+    APIKEY,
+    USE_SSL,
+    VERIFY_SSL,
 )
 
 from .tdarr import Server
@@ -48,6 +50,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     else:
         apikey = ""
 
+    use_ssl = entry.data.get(USE_SSL, False)
+    verify_ssl = entry.data.get(VERIFY_SSL, True)
+
     if UPDATE_INTERVAL in entry.options:
         update_interval = entry.options[UPDATE_INTERVAL]
     else:
@@ -56,7 +61,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     #for ar in entry.data:
         #_LOGGER.debug(ar)
 
-    coordinator = TdarrDataUpdateCoordinator(hass, serverip, serverport, update_interval, apikey)
+    coordinator = TdarrDataUpdateCoordinator(
+        hass, serverip, serverport, update_interval, apikey, use_ssl, verify_ssl
+    )
 
     await coordinator.async_refresh()  # Get initial data
        # Registers update listener to update config entry when options are updated.
@@ -126,12 +133,23 @@ async def options_update_listener(
 class TdarrDataUpdateCoordinator(DataUpdateCoordinator):
     """DataUpdateCoordinator to handle fetching new data about the Tdarr Controller."""
 
-    def __init__(self, hass, serverip, serverport, update_interval, apikey):
+    def __init__(
+        self,
+        hass,
+        serverip,
+        serverport,
+        update_interval,
+        apikey,
+        use_ssl=False,
+        verify_ssl=True,
+    ):
         """Initialize the coordinator and set up the Controller object."""
         self._hass = hass
         self.serverip = serverip
         self.serverport = serverport
-        self.tdarr = Server(serverip, serverport, apikey)
+        self.tdarr = Server(
+            serverip, serverport, apikey, use_ssl=use_ssl, verify_ssl=verify_ssl
+        )
         self._available = True
 
         super().__init__(

--- a/custom_components/tdarr/config_flow.py
+++ b/custom_components/tdarr/config_flow.py
@@ -12,7 +12,9 @@ from .const import (
     SERVERPORT,
     UPDATE_INTERVAL,
     UPDATE_INTERVAL_DEFAULT,
-    APIKEY
+    APIKEY,
+    USE_SSL,
+    VERIFY_SSL,
 )
 from .tdarr import Server
 
@@ -22,7 +24,9 @@ DATA_SCHEMA = vol.Schema(
     {
         vol.Required(SERVERIP): str,
         vol.Required(SERVERPORT, default="8265"): str,
-        vol.Optional(APIKEY, default=""): str
+        vol.Optional(APIKEY, default=""): str,
+        vol.Optional(USE_SSL, default=False): bool,
+        vol.Optional(VERIFY_SSL, default=True): bool,
     }
 )
 
@@ -32,7 +36,13 @@ async def validate_input(hass: core.HomeAssistant, data):
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
     
-    tdarr = Server(data[SERVERIP], data[SERVERPORT], data[APIKEY])
+    tdarr = Server(
+        data[SERVERIP],
+        data[SERVERPORT],
+        data[APIKEY],
+        use_ssl=data.get(USE_SSL, False),
+        verify_ssl=data.get(VERIFY_SSL, True),
+    )
 
     result = await hass.async_add_executor_job(tdarr.getSettings)
     if result.get("status", "") == "ERROR":

--- a/custom_components/tdarr/const.py
+++ b/custom_components/tdarr/const.py
@@ -6,6 +6,8 @@ UPDATE_INTERVAL = "update_interval"
 UPDATE_INTERVAL_DEFAULT = 60
 COORDINATOR = "coordinator"
 APIKEY = "apikey"
+USE_SSL = "use_ssl"
+VERIFY_SSL = "verify_ssl"
 
 SENSORS = {
     "server": {"icon": "mdi:server", "type": "single", "entry": "server"},

--- a/custom_components/tdarr/strings.json
+++ b/custom_components/tdarr/strings.json
@@ -13,9 +13,11 @@
         "step": {
             "user": {
                 "data": {
-                    "serverip": "Tdarr Server IP",
+                    "serverip": "Tdarr Server Host / IP",
                     "serverport": "Tdarr Server Port",
-                    "apikey": "Tdarr API Key (Only if auth is enabled otherwise leave blank"
+                    "apikey": "Tdarr API Key (Only if auth is enabled otherwise leave blank)",
+                    "use_ssl": "Use SSL (HTTPS)",
+                    "verify_ssl": "Verify SSL Certificate"
                 }
             }
         }

--- a/custom_components/tdarr/tdarr.py
+++ b/custom_components/tdarr/tdarr.py
@@ -5,16 +5,18 @@ _LOGGER = logging.getLogger(__name__)
 
 class Server(object):
     # Class representing a tdarr server
-    def __init__(self, url, port, apikey=""):
+    def __init__(self, url, port, apikey="", use_ssl=False, verify_ssl=True):
         self.url = url
-        self.baseurl = 'http://' + self.url + ':' + port + '/api/v2/'
+        scheme = "https" if use_ssl else "http"
+        self.baseurl = f"{scheme}://{self.url}:{port}/api/v2/"
+        self.verify_ssl = verify_ssl
         self.headers = {
             'Content-Type': 'application/json',
             'x-api-key': apikey
         }
-        
+
     def getNodes(self):
-        r = requests.get(self.baseurl + 'get-nodes', headers=self.headers)
+        r = requests.get(self.baseurl + 'get-nodes', headers=self.headers, verify=self.verify_ssl)
         if r.status_code == 200:
             result = r.json()
             return result
@@ -22,13 +24,13 @@ class Server(object):
             return "ERROR"
 
     def getStatus(self):
-        r = requests.get(self.baseurl + 'status', headers=self.headers)
+        r = requests.get(self.baseurl + 'status', headers=self.headers, verify=self.verify_ssl)
         if r.status_code == 200:
             result = r.json()
             return result
         else:
             return "ERROR"
-    
+
     def getLibraries(self):
         libraries = []
         library = self.getPies()
@@ -49,24 +51,24 @@ class Server(object):
                 "mode":"getById",
                 "docID":"statistics",
                 "obj":{}
-                },
+            },
             "timeout":1000
         }
-        r = requests.post(self.baseurl + 'cruddb', json = post, headers=self.headers)
+        r = requests.post(self.baseurl + 'cruddb', json = post, headers=self.headers, verify=self.verify_ssl)
         if r.status_code == 200:
             return r.json()
         else:
             return "ERROR"
-    
+
     def getLibraryStats(self):
         post = {
             "data": {
                 "collection":"LibrarySettingsJSONDB",
                 "mode":"getAll",
-                },
+            },
             "timeout":20000
         }
-        r = requests.post(self.baseurl + 'cruddb', json = post, headers=self.headers)
+        r = requests.post(self.baseurl + 'cruddb', json = post, headers=self.headers, verify=self.verify_ssl)
         if r.status_code == 200:
             return r.json()
         else:
@@ -77,12 +79,12 @@ class Server(object):
                 "libraryId":libraryID
                 },
         }
-        r = requests.post(self.baseurl + 'stats/get-pies', json = post, headers=self.headers)
+        r = requests.post(self.baseurl + 'stats/get-pies', json = post, headers=self.headers, verify=self.verify_ssl)
         if r.status_code == 200:
             return r.json()["pieStats"]
         else:
             return "ERROR"
-        
+
     def getStaged(self):
         post = {
             "data": {
@@ -91,31 +93,31 @@ class Server(object):
                 "pageSize":10,
                 "sorts":[],
                 "opts":{}
-                },
+            },
             "timeout":1000
         }
-        r = requests.post(self.baseurl + 'client/staged', json = post, headers=self.headers)
+        r = requests.post(self.baseurl + 'client/staged', json = post, headers=self.headers, verify=self.verify_ssl)
         if r.status_code == 200:
             return r.json()
         else:
             return "ERROR"
-        
-    def getSettings(self):  
+
+    def getSettings(self):
         post = {
             "data": {
                 "collection":"SettingsGlobalJSONDB",
                 "mode":"getById",
                 "docID":"globalsettings",
                 "obj":{}
-                },
+            },
             "timeout":1000
         }
-        r = requests.post(self.baseurl + 'cruddb', json = post, headers=self.headers)
+        r = requests.post(self.baseurl + 'cruddb', json = post, headers=self.headers, verify=self.verify_ssl)
         if r.status_code == 200:
             return r.json()
         else:
             return {"message": r.text, "status_code": r.status_code, "status": "ERROR"}
-        
+
     def pauseNode(self, nodeID, status):
 
         if nodeID == "pauseAll":
@@ -127,10 +129,10 @@ class Server(object):
                     "obj":{
                         "pauseAllNodes": status
                         }
-                    },
+                },
                     "timeout":20000
-                }
-            r = requests.post(self.baseurl + 'cruddb', json=data, headers=self.headers)
+            }
+            r = requests.post(self.baseurl + 'cruddb', json=data, headers=self.headers, verify=self.verify_ssl)
         elif nodeID == "ignoreSchedules":
             data = {
                 "data":{
@@ -143,7 +145,7 @@ class Server(object):
                     },
                     "timeout":20000
                 }
-            r = requests.post(self.baseurl + 'cruddb', json=data, headers=self.headers)
+            r = requests.post(self.baseurl + 'cruddb', json=data, headers=self.headers, verify=self.verify_ssl)
         else:
             data = {
                 "data": {
@@ -153,7 +155,7 @@ class Server(object):
                     }
                 }
             }
-            r = requests.post(self.baseurl + 'update-node', json=data, headers=self.headers)
+            r = requests.post(self.baseurl + 'update-node', json=data, headers=self.headers, verify=self.verify_ssl)
         if r.status_code == 200:
             return "OK"
         else:
@@ -184,7 +186,7 @@ class Server(object):
             }
         }
 
-        r = requests.post(self.baseurl + "scan-files", json=data, headers=self.headers)
+        r = requests.post(self.baseurl + "scan-files", json=data, headers=self.headers, verify=self.verify_ssl)
 
         if r.status_code == 200:
             _LOGGER.debug(r.text)
@@ -200,4 +202,3 @@ class Server(object):
 
     
 
-    

--- a/custom_components/tdarr/translations/en.json
+++ b/custom_components/tdarr/translations/en.json
@@ -13,9 +13,11 @@
         "step": {
             "user": {
                 "data": {
-                    "serverip": "Tdarr Server IP",
+                    "serverip": "Tdarr Server Host / IP",
                     "serverport": "Tdarr Server Port",
-                    "apikey": "Tdarr API Key (Only if auth is enabled otherwise leave blank)"
+                    "apikey": "Tdarr API Key (Only if auth is enabled otherwise leave blank)",
+                    "use_ssl": "Use SSL (HTTPS)",
+                    "verify_ssl": "Verify SSL Certificate"
                 }
             }
         }


### PR DESCRIPTION
Adds use_ssl and verify_ssl config options so users can connect to Tdarr instances behind an HTTPS reverse proxy. The SSL scheme and certificate verification are propagated from the config flow through to all HTTP requests in the API client.

Solves #46 